### PR TITLE
fix: raise error if http response status is not ok

### DIFF
--- a/src/geolocation.rs
+++ b/src/geolocation.rs
@@ -66,9 +66,14 @@ async fn fetch_location() -> Result<GeoLocation, GeolocationError> {
         .build()
         .map_err(|e| GeolocationError::Unreachable(NetworkError::ClientCreation(e)))?;
 
-    let response = client.get(IPINFO_URL).send().await.map_err(|e| {
-        GeolocationError::Unreachable(NetworkError::from_reqwest(e, IPINFO_URL, 10))
-    })?;
+    let response = client
+        .get(IPINFO_URL)
+        .send()
+        .await
+        .and_then(|resp| resp.error_for_status())
+        .map_err(|e| {
+            GeolocationError::Unreachable(NetworkError::from_reqwest(e, IPINFO_URL, 10))
+        })?;
 
     let ip_info: IpInfoResponse = response.json().await.map_err(|e| {
         GeolocationError::Unreachable(NetworkError::from_reqwest(e, IPINFO_URL, 10))

--- a/src/weather/open_meteo.rs
+++ b/src/weather/open_meteo.rs
@@ -135,6 +135,7 @@ impl WeatherProvider for OpenMeteoProvider {
             .get(&url)
             .send()
             .await
+            .and_then(|resp| resp.error_for_status())
             .map_err(|e| WeatherError::Network(NetworkError::from_reqwest(e, &url, 30)))?;
 
         let data: OpenMeteoResponse = response


### PR DESCRIPTION
Before:

```
saki@MagMilk [ weathr@raise-error-if-geolocation-resp-status-not-ok ] $ weathr
Auto-detecting location...
Received invalid data from location service.
Using configured/default location.
```

After:

```
Auto-detecting location...
Location service returned error (HTTP 429).
Using configured/default location.
```