### PR TITLE
Fix(aad): time parsing for Daylight time

### DIFF
--- a/src/weather/provider/supplementary/aad.rs
+++ b/src/weather/provider/supplementary/aad.rs
@@ -190,7 +190,7 @@ struct SunData {
 
 impl SunData {
     fn get_time(&self) -> String {
-        self.time.clone().replace("  ST", "") // Unsure what ST stands for, but its not needed
+        self.time.clone().replace("  ST", "").replace("  DT", "") // Figured out what ST and DT mean (Standard Time & Daylight Time)
     }
 
     fn to_chrono_time(&self) -> Result<NaiveTime, WeatherError> {


### PR DESCRIPTION
Simple fix to solve #43 , doesn't affect the accuracy of information provided, seems like a issue on the API server side appending incorrect time zone info