### PR TITLE
Update package reference syntax in hm-module.nix

### DIFF
--- a/nix/hm-module.nix
+++ b/nix/hm-module.nix
@@ -21,7 +21,7 @@
 
         package = lib.mkOption {
           type = lib.types.package;
-          default = self.packages.${pkgs.system}.default;
+          default = self.packages.${pkgs.stdenv.hostPlatform.system}.default;
           description = "The weathr package to install.";
         };
 


### PR DESCRIPTION
Fix default package reference for home-manager module to match updated nix syntax.

This PR is targeting the following evaluation warning:
`trace: evaluation warning: 'system' has been renamed to/replaced by 'stdenv.hostPlatform.system'`

Change from:
``` nix
default = self.packages.${pkgs.system}.default;
```
To:
``` nix
default = self.packages.${pkgs.stdenv.hostPlatform.system}.default;
```