### PR TITLE
Add support for optional 'feels like' temperature info

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,6 +196,9 @@ Edit the config file at the appropriate path for your platform:
 # Hide the HUD (Heads Up Display) with weather details
 hide_hud = false
 
+# Display the "feels like" temperature alongside the actual temperature in the HUD
+use_feels_like_temperature = false
+
 # Run silently without startup messages (errors still shown)
 silent = false
 
@@ -209,9 +212,6 @@ auto = false
 
 # Hide the location name in the UI
 hide = false
-
-# Display the "feels like" temperature info alongside the actual temperature.
-use_apparent_temperature = false
 
 # How to display the location in the HUD: "coordinates" | "city" | "mixed"
 display = "mixed"
@@ -308,7 +308,7 @@ weathr --hide-location
 weathr --hide-hud
 
 # Show feels-like temperature alongside actual temperature
-weathr --use-apparent-temperature
+weathr --use-feels-like-temperature
 
 # Run silently (suppress non-error output)
 weathr --silent

--- a/README.md
+++ b/README.md
@@ -210,6 +210,9 @@ auto = false
 # Hide the location name in the UI
 hide = false
 
+# Display the "feels like" temperature info alongside the actual temperature.
+use_apparent_temperature = false
+
 # How to display the location in the HUD: "coordinates" | "city" | "mixed"
 display = "mixed"
 
@@ -303,6 +306,9 @@ weathr --hide-location
 
 # Hide status HUD
 weathr --hide-hud
+
+# Show feels-like temperature alongside actual temperature
+weathr --use-apparent-temperature
 
 # Run silently (suppress non-error output)
 weathr --silent

--- a/src/animation/sunny.rs
+++ b/src/animation/sunny.rs
@@ -250,10 +250,18 @@ mod tests {
             elevation: None,
         };
         let units = WeatherUnits::metric();
-        let mut state = AppState::new(location, None, LocationDisplay::Coordinates, false, units);
+        let mut state = AppState::new(
+            location,
+            None,
+            LocationDisplay::Coordinates,
+            false,
+            false,
+            units,
+        );
         state.current_weather = Some(WeatherData {
             condition: WeatherCondition::Clear,
             temperature: 20.0,
+            apparent_temperature: 22.0,
             precipitation: 0.0,
             wind_speed: 5.0,
             wind_direction: 0.0,
@@ -292,10 +300,18 @@ mod tests {
             elevation: None,
         };
         let units = WeatherUnits::metric();
-        let mut state = AppState::new(location, None, LocationDisplay::Coordinates, false, units);
+        let mut state = AppState::new(
+            location,
+            None,
+            LocationDisplay::Coordinates,
+            false,
+            false,
+            units,
+        );
         state.current_weather = Some(WeatherData {
             condition: WeatherCondition::Clear,
             temperature: 20.0,
+            apparent_temperature: 22.0,
             precipitation: 0.0,
             wind_speed: 5.0,
             wind_direction: 0.0,

--- a/src/animation/sunny.rs
+++ b/src/animation/sunny.rs
@@ -261,7 +261,7 @@ mod tests {
         state.current_weather = Some(WeatherData {
             condition: WeatherCondition::Clear,
             temperature: 20.0,
-            apparent_temperature: 22.0,
+            feels_like_temperature: 22.0,
             precipitation: 0.0,
             wind_speed: 5.0,
             wind_direction: 0.0,
@@ -311,7 +311,7 @@ mod tests {
         state.current_weather = Some(WeatherData {
             condition: WeatherCondition::Clear,
             temperature: 20.0,
-            apparent_temperature: 22.0,
+            feels_like_temperature: 22.0,
             precipitation: 0.0,
             wind_speed: 5.0,
             wind_direction: 0.0,

--- a/src/app.rs
+++ b/src/app.rs
@@ -107,7 +107,7 @@ fn generate_offline_weather(rng: &mut impl rand::Rng) -> WeatherData {
     WeatherData {
         condition,
         temperature: rng.random_range(10.0..25.0),
-        apparent_temperature: rng.random_range(8.0..27.00),
+        feels_like_temperature: rng.random_range(8.0..27.00),
         precipitation: if condition.is_raining() {
             rng.random_range(1.0..5.0)
         } else {
@@ -155,7 +155,7 @@ impl App {
             config.location.city.clone(),
             config.location.display,
             config.location.hide,
-            config.location.use_apparent_temperature,
+            config.use_feels_like_temperature,
             config.units,
         );
         let mut animations = AnimationManager::new(term_width, term_height, show_leaves);
@@ -180,7 +180,7 @@ impl App {
             let weather = WeatherData {
                 condition: simulated_condition,
                 temperature: 20.0,
-                apparent_temperature: 22.0,
+                feels_like_temperature: 22.0,
                 precipitation: if simulated_condition.is_raining() {
                     2.5
                 } else {

--- a/src/app.rs
+++ b/src/app.rs
@@ -107,6 +107,7 @@ fn generate_offline_weather(rng: &mut impl rand::Rng) -> WeatherData {
     WeatherData {
         condition,
         temperature: rng.random_range(10.0..25.0),
+        apparent_temperature: rng.random_range(8.0..27.00),
         precipitation: if condition.is_raining() {
             rng.random_range(1.0..5.0)
         } else {
@@ -154,6 +155,7 @@ impl App {
             config.location.city.clone(),
             config.location.display,
             config.location.hide,
+            config.location.use_apparent_temperature,
             config.units,
         );
         let mut animations = AnimationManager::new(term_width, term_height, show_leaves);
@@ -178,6 +180,7 @@ impl App {
             let weather = WeatherData {
                 condition: simulated_condition,
                 temperature: 20.0,
+                apparent_temperature: 22.0,
                 precipitation: if simulated_condition.is_raining() {
                     2.5
                 } else {

--- a/src/app_state.rs
+++ b/src/app_state.rs
@@ -421,4 +421,67 @@ mod tests {
         );
         assert!(!app.cached_weather_info.contains("("));
     }
+
+    fn make_app_with_apparent_temp(show: bool, temp_unit: TemperatureUnit) -> AppState {
+        let location = WeatherLocation {
+            latitude: 0.0,
+            longitude: 0.0,
+            elevation: None,
+        };
+        let units = WeatherUnits {
+            temperature: temp_unit,
+            wind_speed: WindSpeedUnit::Kmh,
+            precipitation: PrecipitationUnit::Mm,
+        };
+        let mut app = AppState::new(location, None, LocationDisplay::Coordinates, true, show, units);
+        let weather = WeatherData {
+            condition: WeatherCondition::Clear,
+            temperature: 20.0,
+            apparent_temperature: 22.0,
+            precipitation: 0.0,
+            wind_speed: 10.0,
+            wind_direction: 0.0,
+            moon_phase: Some(0.5),
+            timestamp: "2024-01-01T12:00:00Z".to_string(),
+            attribution: "".to_string(),
+            sun: CelestialEvents::from_bool(true),
+        };
+        app.update_weather(weather);
+        app
+    }
+
+    #[test]
+    fn test_apparent_temperature_shown_in_celsius() {
+        let mut app = make_app_with_apparent_temp(true, TemperatureUnit::Celsius);
+        app.update_cached_info();
+        // apparent_temperature is 22.0°C — expect "(~22.0°C)" in the HUD
+        assert!(
+            app.cached_weather_info.contains("(~22.0°C)"),
+            "expected '(~22.0°C)' in: {}",
+            app.cached_weather_info
+        );
+    }
+
+    #[test]
+    fn test_apparent_temperature_hidden_when_disabled() {
+        let mut app = make_app_with_apparent_temp(false, TemperatureUnit::Celsius);
+        app.update_cached_info();
+        assert!(
+            !app.cached_weather_info.contains("(~"),
+            "expected no apparent-temp marker in: {}",
+            app.cached_weather_info
+        );
+    }
+
+    #[test]
+    fn test_apparent_temperature_converted_to_fahrenheit() {
+        let mut app = make_app_with_apparent_temp(true, TemperatureUnit::Fahrenheit);
+        app.update_cached_info();
+        // 22.0°C → 22.0 * 9/5 + 32 = 71.6°F
+        assert!(
+            app.cached_weather_info.contains("(~71.6°F)"),
+            "expected '(~71.6°F)' in: {}",
+            app.cached_weather_info
+        );
+    }
 }

--- a/src/app_state.rs
+++ b/src/app_state.rs
@@ -16,7 +16,7 @@ pub struct AppState {
     pub city_name: Option<String>,
     pub location_display: LocationDisplay,
     pub hide_location: bool,
-    pub show_apparent_temperature: bool,
+    pub use_apparent_temperature: bool,
     pub units: WeatherUnits,
 }
 
@@ -26,7 +26,7 @@ impl AppState {
         city_name: Option<String>,
         location_display: LocationDisplay,
         hide_location: bool,
-        show_apparent_temperature: bool,
+        use_apparent_temperature: bool,
         units: WeatherUnits,
     ) -> Self {
         Self {
@@ -40,7 +40,7 @@ impl AppState {
             city_name,
             location_display,
             hide_location,
-            show_apparent_temperature,
+            use_apparent_temperature,
             units,
         }
     }
@@ -128,7 +128,7 @@ impl AppState {
         };
 
         let apparent_temp_str = if let Some(ref weather) = self.current_weather {
-            if self.show_apparent_temperature {
+            if self.use_apparent_temperature {
                 let (apparent_temp, apparent_temp_unit) =
                     format_temperature(weather.apparent_temperature, self.units.temperature);
                 format!(" (~{:.1}{})", apparent_temp, apparent_temp_unit)

--- a/src/app_state.rs
+++ b/src/app_state.rs
@@ -16,6 +16,7 @@ pub struct AppState {
     pub city_name: Option<String>,
     pub location_display: LocationDisplay,
     pub hide_location: bool,
+    pub show_apparent_temperature: bool,
     pub units: WeatherUnits,
 }
 
@@ -25,6 +26,7 @@ impl AppState {
         city_name: Option<String>,
         location_display: LocationDisplay,
         hide_location: bool,
+        show_apparent_temperature: bool,
         units: WeatherUnits,
     ) -> Self {
         Self {
@@ -38,6 +40,7 @@ impl AppState {
             city_name,
             location_display,
             hide_location,
+            show_apparent_temperature,
             units,
         }
     }
@@ -124,6 +127,18 @@ impl AppState {
             format!(" | Location: {}", label)
         };
 
+        let apparent_temp_str = if let Some(ref weather) = self.current_weather {
+            if self.show_apparent_temperature {
+                let (apparent_temp, apparent_temp_unit) =
+                    format_temperature(weather.apparent_temperature, self.units.temperature);
+                format!(" (~{:.1}{})", apparent_temp, apparent_temp_unit)
+            } else {
+                String::new()
+            }
+        } else {
+            String::new()
+        };
+
         self.cached_weather_info = if let Some(ref weather) = self.current_weather {
             let (temp, temp_unit) = format_temperature(weather.temperature, self.units.temperature);
             let (wind, wind_unit) = format_wind_speed(weather.wind_speed, self.units.wind_speed);
@@ -133,11 +148,12 @@ impl AppState {
             let offline_indicator = if self.is_offline { "OFFLINE | " } else { "" };
 
             format!(
-                "{}Weather: {} | Temp: {:.1}{} | Wind: {:.1}{} | Precip: {:.1}{}{} | Press 'q' to quit",
+                "{}Weather: {} | Temp: {:.1}{}{} | Wind: {:.1}{} | Precip: {:.1}{}{} | Press 'q' to quit",
                 offline_indicator,
                 self.get_condition_text(),
                 temp,
                 temp_unit,
+                apparent_temp_str,
                 wind,
                 wind_unit,
                 precip,
@@ -251,11 +267,12 @@ mod tests {
             wind_speed: WindSpeedUnit::Kmh,
             precipitation: PrecipitationUnit::Mm,
         };
-        let mut app = AppState::new(location, city, display, false, units);
+        let mut app = AppState::new(location, city, display, false, false, units);
 
         let weather = WeatherData {
             condition: WeatherCondition::Clear,
             temperature: 20.0,
+            apparent_temperature: 22.0,
             precipitation: 0.0,
             wind_speed: 10.0,
             wind_direction: 0.0,

--- a/src/app_state.rs
+++ b/src/app_state.rs
@@ -16,7 +16,7 @@ pub struct AppState {
     pub city_name: Option<String>,
     pub location_display: LocationDisplay,
     pub hide_location: bool,
-    pub use_apparent_temperature: bool,
+    pub use_feels_like_temperature: bool,
     pub units: WeatherUnits,
 }
 
@@ -26,7 +26,7 @@ impl AppState {
         city_name: Option<String>,
         location_display: LocationDisplay,
         hide_location: bool,
-        use_apparent_temperature: bool,
+        use_feels_like_temperature: bool,
         units: WeatherUnits,
     ) -> Self {
         Self {
@@ -40,7 +40,7 @@ impl AppState {
             city_name,
             location_display,
             hide_location,
-            use_apparent_temperature,
+            use_feels_like_temperature,
             units,
         }
     }
@@ -128,9 +128,9 @@ impl AppState {
         };
 
         let apparent_temp_str = if let Some(ref weather) = self.current_weather {
-            if self.use_apparent_temperature {
+            if self.use_feels_like_temperature {
                 let (apparent_temp, apparent_temp_unit) =
-                    format_temperature(weather.apparent_temperature, self.units.temperature);
+                    format_temperature(weather.feels_like_temperature, self.units.temperature);
                 format!(" (~{:.1}{})", apparent_temp, apparent_temp_unit)
             } else {
                 String::new()
@@ -272,7 +272,7 @@ mod tests {
         let weather = WeatherData {
             condition: WeatherCondition::Clear,
             temperature: 20.0,
-            apparent_temperature: 22.0,
+            feels_like_temperature: 22.0,
             precipitation: 0.0,
             wind_speed: 10.0,
             wind_direction: 0.0,
@@ -433,11 +433,18 @@ mod tests {
             wind_speed: WindSpeedUnit::Kmh,
             precipitation: PrecipitationUnit::Mm,
         };
-        let mut app = AppState::new(location, None, LocationDisplay::Coordinates, true, show, units);
+        let mut app = AppState::new(
+            location,
+            None,
+            LocationDisplay::Coordinates,
+            true,
+            show,
+            units,
+        );
         let weather = WeatherData {
             condition: WeatherCondition::Clear,
             temperature: 20.0,
-            apparent_temperature: 22.0,
+            feels_like_temperature: 22.0,
             precipitation: 0.0,
             wind_speed: 10.0,
             wind_direction: 0.0,
@@ -451,10 +458,10 @@ mod tests {
     }
 
     #[test]
-    fn test_apparent_temperature_shown_in_celsius() {
+    fn test_feels_like_temperature_shown_in_celsius() {
         let mut app = make_app_with_apparent_temp(true, TemperatureUnit::Celsius);
         app.update_cached_info();
-        // apparent_temperature is 22.0°C — expect "(~22.0°C)" in the HUD
+        // feels_like_temperature is 22.0°C — expect "(~22.0°C)" in the HUD
         assert!(
             app.cached_weather_info.contains("(~22.0°C)"),
             "expected '(~22.0°C)' in: {}",
@@ -463,7 +470,7 @@ mod tests {
     }
 
     #[test]
-    fn test_apparent_temperature_hidden_when_disabled() {
+    fn test_feels_like_temperature_hidden_when_disabled() {
         let mut app = make_app_with_apparent_temp(false, TemperatureUnit::Celsius);
         app.update_cached_info();
         assert!(
@@ -474,7 +481,7 @@ mod tests {
     }
 
     #[test]
-    fn test_apparent_temperature_converted_to_fahrenheit() {
+    fn test_feels_like_temperature_converted_to_fahrenheit() {
         let mut app = make_app_with_apparent_temp(true, TemperatureUnit::Fahrenheit);
         app.update_cached_info();
         // 22.0°C → 22.0 * 9/5 + 32 = 71.6°F

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -59,6 +59,9 @@ pub struct Cli {
     #[arg(long, help = "Hide HUD (status line)")]
     pub hide_hud: bool,
 
+    #[arg(long, help = "Use apparent temperature alongside actual temperature")]
+    pub use_apparent_temperature: bool,
+
     #[arg(
         long,
         conflicts_with = "metric",

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -60,7 +60,7 @@ pub struct Cli {
     pub hide_hud: bool,
 
     #[arg(long, help = "Use apparent temperature alongside actual temperature")]
-    pub use_apparent_temperature: bool,
+    pub use_feels_like_temperature: bool,
 
     #[arg(
         long,

--- a/src/config.rs
+++ b/src/config.rs
@@ -28,6 +28,8 @@ pub struct Config {
     #[serde(default)]
     pub hide_hud: bool,
     #[serde(default)]
+    pub use_feels_like_temperature: bool,
+    #[serde(default)]
     pub units: WeatherUnits,
     #[serde(default)]
     pub silent: bool,
@@ -62,8 +64,6 @@ pub struct Location {
     pub city: Option<String>,
     #[serde(default)]
     pub display: LocationDisplay,
-    #[serde(default)]
-    pub use_apparent_temperature: bool,
     #[serde(default = "default_city_name_language")]
     pub city_name_language: String,
 }
@@ -89,7 +89,6 @@ impl Default for Location {
             hide: false,
             city: None,
             display: LocationDisplay::default(),
-            use_apparent_temperature: false,
             city_name_language: default_city_name_language(),
         }
     }
@@ -363,10 +362,10 @@ longitude = 0.0
                 hide: false,
                 city: None,
                 display: LocationDisplay::default(),
-                use_apparent_temperature: false,
                 city_name_language: "auto".to_string(),
             },
             hide_hud: false,
+            use_feels_like_temperature: false,
             units: WeatherUnits::default(),
             silent: false,
             provider: HashMap::new(),
@@ -387,10 +386,10 @@ longitude = 0.0
                 hide: false,
                 city: None,
                 display: LocationDisplay::default(),
-                use_apparent_temperature: false,
                 city_name_language: "auto".to_string(),
             },
             hide_hud: false,
+            use_feels_like_temperature: false,
             units: WeatherUnits::default(),
             silent: false,
             provider: HashMap::new(),
@@ -411,10 +410,10 @@ longitude = 0.0
                 hide: false,
                 city: None,
                 display: LocationDisplay::default(),
-                use_apparent_temperature: false,
                 city_name_language: "auto".to_string(),
             },
             hide_hud: false,
+            use_feels_like_temperature: false,
             units: WeatherUnits::default(),
             silent: false,
             provider: HashMap::new(),
@@ -435,10 +434,10 @@ longitude = 0.0
                 hide: false,
                 city: None,
                 display: LocationDisplay::default(),
-                use_apparent_temperature: false,
                 city_name_language: "auto".to_string(),
             },
             hide_hud: false,
+            use_feels_like_temperature: false,
             units: WeatherUnits::default(),
             silent: false,
             provider: HashMap::new(),
@@ -459,10 +458,10 @@ longitude = 0.0
                 hide: false,
                 city: None,
                 display: LocationDisplay::default(),
-                use_apparent_temperature: false,
                 city_name_language: "auto".to_string(),
             },
             hide_hud: false,
+            use_feels_like_temperature: false,
             units: WeatherUnits::default(),
             silent: false,
             provider: HashMap::new(),

--- a/src/config.rs
+++ b/src/config.rs
@@ -62,6 +62,8 @@ pub struct Location {
     pub city: Option<String>,
     #[serde(default)]
     pub display: LocationDisplay,
+    #[serde(default)]
+    pub use_apparent_temperature: bool,
     #[serde(default = "default_city_name_language")]
     pub city_name_language: String,
 }
@@ -87,6 +89,7 @@ impl Default for Location {
             hide: false,
             city: None,
             display: LocationDisplay::default(),
+            use_apparent_temperature: false,
             city_name_language: default_city_name_language(),
         }
     }
@@ -360,6 +363,7 @@ longitude = 0.0
                 hide: false,
                 city: None,
                 display: LocationDisplay::default(),
+                use_apparent_temperature: false,
                 city_name_language: "auto".to_string(),
             },
             hide_hud: false,
@@ -383,6 +387,7 @@ longitude = 0.0
                 hide: false,
                 city: None,
                 display: LocationDisplay::default(),
+                use_apparent_temperature: false,
                 city_name_language: "auto".to_string(),
             },
             hide_hud: false,
@@ -406,6 +411,7 @@ longitude = 0.0
                 hide: false,
                 city: None,
                 display: LocationDisplay::default(),
+                use_apparent_temperature: false,
                 city_name_language: "auto".to_string(),
             },
             hide_hud: false,
@@ -429,6 +435,7 @@ longitude = 0.0
                 hide: false,
                 city: None,
                 display: LocationDisplay::default(),
+                use_apparent_temperature: false,
                 city_name_language: "auto".to_string(),
             },
             hide_hud: false,
@@ -452,6 +459,7 @@ longitude = 0.0
                 hide: false,
                 city: None,
                 display: LocationDisplay::default(),
+                use_apparent_temperature: false,
                 city_name_language: "auto".to_string(),
             },
             hide_hud: false,

--- a/src/main.rs
+++ b/src/main.rs
@@ -84,8 +84,8 @@ async fn main() -> io::Result<()> {
     if cli.hide_location {
         config.location.hide = true;
     }
-    if cli.use_apparent_temperature {
-        config.location.use_apparent_temperature = true;
+    if cli.use_feels_like_temperature {
+        config.use_feels_like_temperature = true;
     }
     if cli.hide_hud {
         config.hide_hud = true;

--- a/src/main.rs
+++ b/src/main.rs
@@ -84,6 +84,9 @@ async fn main() -> io::Result<()> {
     if cli.hide_location {
         config.location.hide = true;
     }
+    if cli.use_apparent_temperature {
+        config.location.use_apparent_temperature = true;
+    }
     if cli.hide_hud {
         config.hide_hud = true;
     }

--- a/src/weather/normalizer.rs
+++ b/src/weather/normalizer.rs
@@ -112,6 +112,7 @@ mod tests {
 
         assert_eq!(data.condition, WeatherCondition::Rain);
         assert_eq!(data.temperature, 20.5);
+        assert_eq!(data.apparent_temperature, 22.5);
         assert!(data.sun.is_day);
         assert_eq!(data.moon_phase, Some(0.5));
     }

--- a/src/weather/normalizer.rs
+++ b/src/weather/normalizer.rs
@@ -10,7 +10,7 @@ impl WeatherNormalizer {
         WeatherData {
             condition,
             temperature: response.temperature,
-            apparent_temperature: response.apparent_temperature,
+            feels_like_temperature: response.feels_like_temperature,
             precipitation: response.precipitation,
             wind_speed: response.wind_speed,
             wind_direction: response.wind_direction,
@@ -98,7 +98,7 @@ mod tests {
         let response = WeatherProviderResponse {
             weather_code: 61,
             temperature: 20.5,
-            apparent_temperature: 22.5,
+            feels_like_temperature: 22.5,
             precipitation: 2.5,
             wind_speed: 15.0,
             wind_direction: 180.0,
@@ -112,7 +112,7 @@ mod tests {
 
         assert_eq!(data.condition, WeatherCondition::Rain);
         assert_eq!(data.temperature, 20.5);
-        assert_eq!(data.apparent_temperature, 22.5);
+        assert_eq!(data.feels_like_temperature, 22.5);
         assert!(data.sun.is_day);
         assert_eq!(data.moon_phase, Some(0.5));
     }

--- a/src/weather/normalizer.rs
+++ b/src/weather/normalizer.rs
@@ -10,6 +10,7 @@ impl WeatherNormalizer {
         WeatherData {
             condition,
             temperature: response.temperature,
+            apparent_temperature: response.apparent_temperature,
             precipitation: response.precipitation,
             wind_speed: response.wind_speed,
             wind_direction: response.wind_direction,
@@ -97,6 +98,7 @@ mod tests {
         let response = WeatherProviderResponse {
             weather_code: 61,
             temperature: 20.5,
+            apparent_temperature: 22.5,
             precipitation: 2.5,
             wind_speed: 15.0,
             wind_direction: 180.0,

--- a/src/weather/provider/met_office.rs
+++ b/src/weather/provider/met_office.rs
@@ -193,6 +193,12 @@ impl WeatherProvider for MetOfficeProvider {
                 current_weather.screen_temperature,
                 "screenTemperature",
             )?,
+            apparent_temperature: current_weather.normalize_temperature(
+                units,
+                &data.parameters,
+                current_weather.feels_like_temperature,
+                "feelsLikeTemperature",
+            )?,
             precipitation: current_weather.normalize_precipitation_rate(units, &data.parameters)?,
             wind_speed: current_weather.normalize_wind_speeds(
                 units,

--- a/src/weather/provider/met_office.rs
+++ b/src/weather/provider/met_office.rs
@@ -193,7 +193,7 @@ impl WeatherProvider for MetOfficeProvider {
                 current_weather.screen_temperature,
                 "screenTemperature",
             )?,
-            apparent_temperature: current_weather.normalize_temperature(
+            feels_like_temperature: current_weather.normalize_temperature(
                 units,
                 &data.parameters,
                 current_weather.feels_like_temperature,

--- a/src/weather/provider/mod.rs
+++ b/src/weather/provider/mod.rs
@@ -11,6 +11,7 @@ pub mod supplementary;
 pub struct WeatherProviderResponse {
     pub weather_code: i32,
     pub temperature: f64,
+    pub apparent_temperature: f64,
     pub precipitation: f64,
     pub wind_speed: f64,
     pub wind_direction: f64,

--- a/src/weather/provider/mod.rs
+++ b/src/weather/provider/mod.rs
@@ -11,7 +11,7 @@ pub mod supplementary;
 pub struct WeatherProviderResponse {
     pub weather_code: i32,
     pub temperature: f64,
-    pub apparent_temperature: f64,
+    pub feels_like_temperature: f64,
     pub precipitation: f64,
     pub wind_speed: f64,
     pub wind_direction: f64,

--- a/src/weather/provider/open_meteo.rs
+++ b/src/weather/provider/open_meteo.rs
@@ -26,6 +26,7 @@ struct OpenMeteoResponse {
 struct CurrentWeather {
     time: String,
     temperature_2m: f64,
+    apparent_temperature: f64,
     #[serde(deserialize_with = "deserialize_i32_from_number")]
     is_day: i32,
     precipitation: f64,
@@ -100,7 +101,7 @@ impl OpenMeteoProvider {
 
     fn build_url(&self, location: &WeatherLocation, units: &WeatherUnits) -> String {
         format!(
-            "{}?latitude={}&longitude={}&current=temperature_2m,is_day,precipitation,weather_code,wind_speed_10m,wind_direction_10m&temperature_unit={}&wind_speed_unit={}&precipitation_unit={}&timezone=auto",
+            "{}?latitude={}&longitude={}&current=temperature_2m,apparent_temperature,is_day,precipitation,weather_code,wind_speed_10m,wind_direction_10m&temperature_unit={}&wind_speed_unit={}&precipitation_unit={}&timezone=auto",
             self.base_url,
             location.latitude,
             location.longitude,
@@ -147,6 +148,10 @@ impl WeatherProvider for OpenMeteoProvider {
         Ok(WeatherProviderResponse {
             weather_code: data.current.weather_code,
             temperature: normalize_temperature(data.current.temperature_2m, units.temperature),
+            apparent_temperature: normalize_temperature(
+                data.current.apparent_temperature,
+                units.temperature,
+            ),
             precipitation: normalize_precipitation(data.current.precipitation, units.precipitation),
             wind_speed: normalize_wind_speed(data.current.wind_speed_10m, units.wind_speed),
             wind_direction: data.current.wind_direction_10m,

--- a/src/weather/provider/open_meteo.rs
+++ b/src/weather/provider/open_meteo.rs
@@ -148,7 +148,7 @@ impl WeatherProvider for OpenMeteoProvider {
         Ok(WeatherProviderResponse {
             weather_code: data.current.weather_code,
             temperature: normalize_temperature(data.current.temperature_2m, units.temperature),
-            apparent_temperature: normalize_temperature(
+            feels_like_temperature: normalize_temperature(
                 data.current.apparent_temperature,
                 units.temperature,
             ),

--- a/src/weather/types.rs
+++ b/src/weather/types.rs
@@ -207,7 +207,7 @@ pub enum PrecipitationUnit {
 pub struct WeatherData {
     pub condition: WeatherCondition,
     pub temperature: f64,
-    pub apparent_temperature: f64,
+    pub feels_like_temperature: f64,
     pub precipitation: f64,
     pub wind_speed: f64,
     pub wind_direction: f64,

--- a/src/weather/types.rs
+++ b/src/weather/types.rs
@@ -207,6 +207,7 @@ pub enum PrecipitationUnit {
 pub struct WeatherData {
     pub condition: WeatherCondition,
     pub temperature: f64,
+    pub apparent_temperature: f64,
     pub precipitation: f64,
     pub wind_speed: f64,
     pub wind_direction: f64,

--- a/tests/weather_normalizer_integration_test.rs
+++ b/tests/weather_normalizer_integration_test.rs
@@ -113,6 +113,7 @@ fn test_weather_normalizer_integration_clear_conditions() {
 
     assert_eq!(weather.condition, WeatherCondition::Clear);
     assert_eq!(weather.temperature, 22.5);
+    assert_eq!(weather.apparent_temperature, 24.0);
     assert_eq!(weather.precipitation, 0.0);
     assert!(weather.sun.is_day);
 }
@@ -135,6 +136,7 @@ fn test_weather_normalizer_integration_rainy_conditions() {
     let weather = WeatherNormalizer::normalize(response);
 
     assert_eq!(weather.condition, WeatherCondition::Rain);
+    assert_eq!(weather.apparent_temperature, 17.0);
     assert_eq!(weather.precipitation, 5.2);
 }
 
@@ -156,6 +158,7 @@ fn test_weather_normalizer_integration_snowy_conditions() {
     let weather = WeatherNormalizer::normalize(response);
 
     assert_eq!(weather.condition, WeatherCondition::Snow);
+    assert_eq!(weather.apparent_temperature, -1.0);
     assert!(weather.temperature < 0.0);
     assert!(!weather.sun.is_day);
 }

--- a/tests/weather_normalizer_integration_test.rs
+++ b/tests/weather_normalizer_integration_test.rs
@@ -40,6 +40,7 @@ fn test_weather_normalizer_integration_all_wmo_codes() {
         let response = WeatherProviderResponse {
             weather_code: code,
             temperature: 20.0,
+            apparent_temperature: 22.0,
             precipitation: 0.0,
             wind_speed: 10.0,
             wind_direction: 180.0,
@@ -63,6 +64,7 @@ fn test_weather_normalizer_integration_day_night() {
     let response_day = WeatherProviderResponse {
         weather_code: 0,
         temperature: 20.0,
+        apparent_temperature: 22.0,
         precipitation: 0.0,
         wind_speed: 10.0,
         wind_direction: 180.0,
@@ -75,6 +77,7 @@ fn test_weather_normalizer_integration_day_night() {
     let response_night = WeatherProviderResponse {
         weather_code: 0,
         temperature: 15.0,
+        apparent_temperature: 17.0,
         precipitation: 0.0,
         wind_speed: 5.0,
         wind_direction: 180.0,
@@ -96,6 +99,7 @@ fn test_weather_normalizer_integration_clear_conditions() {
     let response = WeatherProviderResponse {
         weather_code: 0,
         temperature: 22.5,
+        apparent_temperature: 24.0,
         precipitation: 0.0,
         wind_speed: 5.0,
         wind_direction: 90.0,
@@ -118,6 +122,7 @@ fn test_weather_normalizer_integration_rainy_conditions() {
     let response = WeatherProviderResponse {
         weather_code: 61,
         temperature: 15.0,
+        apparent_temperature: 17.0,
         precipitation: 5.2,
         wind_speed: 12.0,
         wind_direction: 270.0,
@@ -138,6 +143,7 @@ fn test_weather_normalizer_integration_snowy_conditions() {
     let response = WeatherProviderResponse {
         weather_code: 71,
         temperature: -2.0,
+        apparent_temperature: -1.0,
         precipitation: 3.5,
         wind_speed: 8.0,
         wind_direction: 0.0,

--- a/tests/weather_normalizer_integration_test.rs
+++ b/tests/weather_normalizer_integration_test.rs
@@ -40,7 +40,7 @@ fn test_weather_normalizer_integration_all_wmo_codes() {
         let response = WeatherProviderResponse {
             weather_code: code,
             temperature: 20.0,
-            apparent_temperature: 22.0,
+            feels_like_temperature: 22.0,
             precipitation: 0.0,
             wind_speed: 10.0,
             wind_direction: 180.0,
@@ -64,7 +64,7 @@ fn test_weather_normalizer_integration_day_night() {
     let response_day = WeatherProviderResponse {
         weather_code: 0,
         temperature: 20.0,
-        apparent_temperature: 22.0,
+        feels_like_temperature: 22.0,
         precipitation: 0.0,
         wind_speed: 10.0,
         wind_direction: 180.0,
@@ -77,7 +77,7 @@ fn test_weather_normalizer_integration_day_night() {
     let response_night = WeatherProviderResponse {
         weather_code: 0,
         temperature: 15.0,
-        apparent_temperature: 17.0,
+        feels_like_temperature: 17.0,
         precipitation: 0.0,
         wind_speed: 5.0,
         wind_direction: 180.0,
@@ -99,7 +99,7 @@ fn test_weather_normalizer_integration_clear_conditions() {
     let response = WeatherProviderResponse {
         weather_code: 0,
         temperature: 22.5,
-        apparent_temperature: 24.0,
+        feels_like_temperature: 24.0,
         precipitation: 0.0,
         wind_speed: 5.0,
         wind_direction: 90.0,
@@ -113,7 +113,7 @@ fn test_weather_normalizer_integration_clear_conditions() {
 
     assert_eq!(weather.condition, WeatherCondition::Clear);
     assert_eq!(weather.temperature, 22.5);
-    assert_eq!(weather.apparent_temperature, 24.0);
+    assert_eq!(weather.feels_like_temperature, 24.0);
     assert_eq!(weather.precipitation, 0.0);
     assert!(weather.sun.is_day);
 }
@@ -123,7 +123,7 @@ fn test_weather_normalizer_integration_rainy_conditions() {
     let response = WeatherProviderResponse {
         weather_code: 61,
         temperature: 15.0,
-        apparent_temperature: 17.0,
+        feels_like_temperature: 17.0,
         precipitation: 5.2,
         wind_speed: 12.0,
         wind_direction: 270.0,
@@ -136,7 +136,7 @@ fn test_weather_normalizer_integration_rainy_conditions() {
     let weather = WeatherNormalizer::normalize(response);
 
     assert_eq!(weather.condition, WeatherCondition::Rain);
-    assert_eq!(weather.apparent_temperature, 17.0);
+    assert_eq!(weather.feels_like_temperature, 17.0);
     assert_eq!(weather.precipitation, 5.2);
 }
 
@@ -145,7 +145,7 @@ fn test_weather_normalizer_integration_snowy_conditions() {
     let response = WeatherProviderResponse {
         weather_code: 71,
         temperature: -2.0,
-        apparent_temperature: -1.0,
+        feels_like_temperature: -1.0,
         precipitation: 3.5,
         wind_speed: 8.0,
         wind_direction: 0.0,
@@ -158,7 +158,7 @@ fn test_weather_normalizer_integration_snowy_conditions() {
     let weather = WeatherNormalizer::normalize(response);
 
     assert_eq!(weather.condition, WeatherCondition::Snow);
-    assert_eq!(weather.apparent_temperature, -1.0);
+    assert_eq!(weather.feels_like_temperature, -1.0);
     assert!(weather.temperature < 0.0);
     assert!(!weather.sun.is_day);
 }


### PR DESCRIPTION
Adds support for displaying the feels-like temperature alongside the actual temperature in the HUD.

<img width="1921" height="435" alt="image" src="https://github.com/user-attachments/assets/066c689e-0fda-4b89-9e90-92b1d34e5733" />

# What's new

## Feature

- Fetches `feels_like_temperature` from the Open-Meteo (`apparent_temperature` field) and Met Office (`feelsLikeTemperature` field) APIs and propagates it through the full stack: `provider response → normalizer → WeatherData → AppState`
- When enabled, the feels-like value is rendered next to the actual temperature in the status line as `(~<value><unit>)`.
  Example: `Temp: 20.0°C (~22.0°C)`
- Respects the configured temperature unit (Celsius / Fahrenheit).

## Configuration

Opt-in, disabled by default. Can be enabled in two ways:

### config.toml

```toml
use_feels_like_temperature = true
```

### CLI flag

```shell
weathr --use-feels-like-temperature
```

## Tests added

- `app_state` — three new cases: feels-like temperature shown in Celsius, hidden when the flag is off, and correctly converted to Fahrenheit (22.0°C → 71.6°F).
- `normalizer` unit test — asserts the `feels_like_temperature` field is correctly passed through after normalization.
- `weather_normalizer` integration tests — asserts `feels_like_temperature` is preserved for clear, rainy, and snowy conditions.

# Checklist

- [x] Works with both providers (Open-Meteo, Met Office)
- [x] Opt-in via config file and CLI flag
- [x] Unit conversion respected
- [x] Tests added for normalization, HUD formatting, and unit conversion
- [x] Document new setting in `README.md`
